### PR TITLE
fix: replace path seperator in getName

### DIFF
--- a/.yarn/versions/738a0150.yml
+++ b/.yarn/versions/738a0150.yml
@@ -1,2 +1,0 @@
-releases:
-  typedoc-theme-hierarchy: patch

--- a/.yarn/versions/738a0150.yml
+++ b/.yarn/versions/738a0150.yml
@@ -1,0 +1,2 @@
+releases:
+  typedoc-theme-hierarchy: patch

--- a/.yarn/versions/aa836340.yml
+++ b/.yarn/versions/aa836340.yml
@@ -1,2 +1,0 @@
-releases:
-  typedoc-theme-hierarchy: major

--- a/.yarn/versions/aa836340.yml
+++ b/.yarn/versions/aa836340.yml
@@ -1,0 +1,2 @@
+releases:
+  typedoc-theme-hierarchy: major

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-theme-hierarchy",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": "git@github.com:DiFuks/typedoc-theme-hierarchy.git",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack-cli": "^4.9.1"
   },
   "peerDependencies": {
-    "typedoc": "^0.23.6 || ^0.24.0"
+    "typedoc": "^0.23.6"
   },
   "scripts": {
     "build": "webpack && tsc --project tsconfig.build.json",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^8.18.0",
     "eslint-config-fuks": "^1.6.7",
     "mini-css-extract-plugin": "^2.4.5",
+    "path": "^0.12.7",
     "terser-webpack-plugin": "^5.3.3",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-theme-hierarchy",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": "git@github.com:DiFuks/typedoc-theme-hierarchy.git",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "terser-webpack-plugin": "^5.3.3",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.8.1",
-    "typedoc": "^0.23.6",
+    "typedoc": "^0.24.8",
     "typescript": "^4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1"
   },
   "peerDependencies": {
-    "typedoc": "^0.23.6"
+    "typedoc": "^0.24.0"
   },
   "scripts": {
     "build": "webpack && tsc --project tsconfig.build.json",

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ npm i typedoc-theme-hierarchy@^2.0.0 -D
 
 # For typedoc ^0.23.6
 npm i typedoc-theme-hierarchy@^3.0.0 -D
+
+# For typedoc ^0.24.0
+npm i typedoc-theme-hierarchy@^4.0.0 -D
 ```
 
 ## Usage

--- a/src/partials/navigation.tsx
+++ b/src/partials/navigation.tsx
@@ -8,6 +8,7 @@ import {
   ReflectionKind,
 } from 'typedoc';
 import { DeclarationReflection } from 'typedoc/dist/lib/models/reflections/declaration';
+import path from 'path';
 
 interface IDeclarationItem {
   title: string;
@@ -181,8 +182,10 @@ const Item = (
 
 const getName = (item: DeclarationReflection): string => {
   const fullFileName = item.sources?.[0]?.fullFileName || '';
+  const targetFileName = fullFileName.replaceAll(path.sep, '/');
+  const currentDirName = process.cwd().replaceAll(path.sep, '/');
 
-  return fullFileName.replace(`${process.cwd()}`, '').slice(1);
+  return targetFileName.replace(`${currentDirName}`, '').slice(1);
 };
 
 const formatFileHierarchy = (values: DeclarationReflection[]): ICategory => {

--- a/src/partials/navigation.tsx
+++ b/src/partials/navigation.tsx
@@ -38,7 +38,6 @@ export const navigation =
 
     return (
       <div class='tree'>
-        <div class='tree-settings'>{context.settings()}</div>
         <div class='tree-config'>
           <button
             class='tree-config__button tree-config__button--expand js-tree-expand'
@@ -141,7 +140,7 @@ const Item = (
         </a>
         <ul>
           {item.children.map((subItem) => (
-            <li class={subItem.cssClasses}>
+            <li>
               <a
                 class='category__link js-category-link'
                 href={item.context.urlTo(subItem)}
@@ -164,7 +163,7 @@ const Item = (
       </span>
       <ul>
         {item.children.map((subItem) => (
-          <li class={subItem.cssClasses}>
+          <li>
             <a
               class='category__link js-category-link'
               href={item.context.urlTo(subItem)}

--- a/src/themes/OverrideTheme.tsx
+++ b/src/themes/OverrideTheme.tsx
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { copy } from 'fs-extra';
-import { DefaultTheme, RendererEvent } from 'typedoc';
+import { DefaultTheme, PageEvent, Reflection, RendererEvent } from 'typedoc';
 import { Renderer } from 'typedoc/dist/lib/output/renderer';
 
 import { OverrideThemeContext } from './OverrideThemeContext';
@@ -28,9 +28,12 @@ export class OverrideTheme extends DefaultTheme {
   /**
    * Переопределяет стандартный контекст.
    */
-  public override getRenderContext(): OverrideThemeContext {
+  public override getRenderContext(
+    page: PageEvent<Reflection>,
+  ): OverrideThemeContext {
     this._contextCache ||= new OverrideThemeContext(
       this,
+      page,
       this.application.options,
     );
 

--- a/src/themes/OverrideThemeContext.tsx
+++ b/src/themes/OverrideThemeContext.tsx
@@ -1,9 +1,19 @@
-import { DefaultTheme, DefaultThemeRenderContext, Options } from 'typedoc';
+import {
+  DefaultTheme,
+  DefaultThemeRenderContext,
+  Options,
+  PageEvent,
+  Reflection,
+} from 'typedoc';
 import { navigation } from '../partials/navigation';
 
 export class OverrideThemeContext extends DefaultThemeRenderContext {
-  public constructor(theme: DefaultTheme, options: Options) {
-    super(theme, options);
+  public constructor(
+    theme: DefaultTheme,
+    page: PageEvent<Reflection>,
+    options: Options,
+  ) {
+    super(theme, page, options);
 
     this.navigation = navigation(this);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable"],
+    "lib": ["DOM", "DOM.Iterable", "ES2021.String"],
     "baseUrl": ".",
     "target": "es2016",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "ansi-sequence-parser@npm:1.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-sequence-parser%2F-%2Fansi-sequence-parser-1.1.0.tgz"
+  checksum: 75f4d3a4c555655a698aec05b5763cbddcd16ccccdbfd178fb0aa471ab74fdf98e031b875ef26e64be6a95cf970c89238744b26de6e34af97f316d5186b1df53
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -3506,10 +3513,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "jsonc-parser@npm:3.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonc-parser%2F-%2Fjsonc-parser-3.0.0.tgz"
-  checksum: 1df2326f1f9688de30c70ff19c5b2a83ba3b89a1036160da79821d1361090775e9db502dc57a67c11b56e1186fc1ed70b887f25c5febf9a3ec4f91435836c99d
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonc-parser%2F-%2Fjsonc-parser-3.2.0.tgz"
+  checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
   languageName: node
   linkType: hard
 
@@ -3701,12 +3708,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.0.16":
-  version: 4.0.17
-  resolution: "marked@npm:4.0.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-4.0.17.tgz"
+"marked@npm:^4.2.12":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-4.3.0.tgz"
   bin:
     marked: bin/marked.js
-  checksum: 33a3c43a20b47bddaf045a59bfc7c3d41cc321931cc663ed231ca3b5b3b195fb2ac2973e687c2afd65b79539c14619baa07d19793f70130160f0af80c06d9b3a
+  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -4113,12 +4120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "minimatch@npm:5.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-5.1.0.tgz"
+"minimatch@npm:^7.1.3":
+  version: 7.4.6
+  resolution: "minimatch@npm:7.4.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-7.4.6.tgz"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 15ce53d31a06361e8b7a629501b5c75491bc2b59712d53e802b1987121d91b433d73fcc5be92974fde66b2b51d8fb28d75a9ae900d249feb792bb1ba2a4f0a90
+  checksum: 1a6c8d22618df9d2a88aabeef1de5622eb7b558e9f8010be791cb6b0fa6e102d39b11c28d75b855a1e377b12edc7db8ff12a99c20353441caa6a05e78deb5da9
   languageName: node
   linkType: hard
 
@@ -5434,14 +5441,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "shiki@npm:0.10.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fshiki%2F-%2Fshiki-0.10.1.tgz"
+"shiki@npm:^0.14.1":
+  version: 0.14.2
+  resolution: "shiki@npm:0.14.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fshiki%2F-%2Fshiki-0.14.2.tgz"
   dependencies:
-    jsonc-parser: ^3.0.0
-    vscode-oniguruma: ^1.6.1
-    vscode-textmate: 5.2.0
-  checksum: fb746f3cb3de7e545e3b10a6cb658d3938f840e4ccc9a3c90ceb7e69a8f89dbb432171faac1e9f02a03f103684dad88ee5e54b5c4964fa6b579fca6e8e26424d
+    ansi-sequence-parser: ^1.1.0
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: f2a14302b1803617e3ff1b751a5c87b4af4ad15214dc00e9215402e42940a84a0b956cf55d628f25dbf1296b18e277b8529571cd9359b971ac599a0ab11303e7
   languageName: node
   linkType: hard
 
@@ -5975,7 +5983,7 @@ __metadata:
     terser-webpack-plugin: ^5.3.3
     ts-loader: ^9.2.6
     ts-node: ^10.8.1
-    typedoc: ^0.23.6
+    typedoc: 0.24.0
     typescript: ^4.7.4
     webpack: ^5.65.0
     webpack-cli: ^4.9.1
@@ -5984,19 +5992,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"typedoc@npm:^0.23.6":
-  version: 0.23.6
-  resolution: "typedoc@npm:0.23.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.23.6.tgz"
+"typedoc@npm:0.24.0":
+  version: 0.24.0
+  resolution: "typedoc@npm:0.24.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.24.0.tgz"
   dependencies:
     lunr: ^2.3.9
-    marked: ^4.0.16
-    minimatch: ^5.1.0
-    shiki: ^0.10.1
+    marked: ^4.2.12
+    minimatch: ^7.1.3
+    shiki: ^0.14.1
   peerDependencies:
-    typescript: 4.6.x || 4.7.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: 74db2eedec4af4764b182d83f7d9ba20f934b7b1ff989de72f104cf173baeca90221e044c3229e7f2df58590078ead3fc5eca3b0088214e588d9d1da0b85ee58
+  checksum: 2c53037a8bc448713453e2f314265be058adff64710a83bd0d50a65ac72d4117265d89609c40da46fcd3e35c833f1641ec7c2ecb4b59cc29b8f46e4da5e4d50a
   languageName: node
   linkType: hard
 
@@ -6238,17 +6246,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-oniguruma@npm:^1.6.1":
-  version: 1.6.2
-  resolution: "vscode-oniguruma@npm:1.6.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fvscode-oniguruma%2F-%2Fvscode-oniguruma-1.6.2.tgz"
-  checksum: 6b754acdafd5b68242ea5938bb00a32effc16c77f471d4f0f337d879d0e8e592622998e2441f42d9a7ff799c1593f31c11f26ca8d9bf9917e3ca881d3c1f3e19
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fvscode-oniguruma%2F-%2Fvscode-oniguruma-1.7.0.tgz"
+  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
   languageName: node
   linkType: hard
 
-"vscode-textmate@npm:5.2.0":
-  version: 5.2.0
-  resolution: "vscode-textmate@npm:5.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fvscode-textmate%2F-%2Fvscode-textmate-5.2.0.tgz"
-  checksum: 5449b42d451080f6f3649b66948f4b5ee4643c4e88cfe3558a3b31c84c78060cfdd288c4958c1690eaa5cd65d09992fa6b7c3bef9d4aa72b3651054a04624d20
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fvscode-textmate%2F-%2Fvscode-textmate-8.0.0.tgz"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5983,18 +5983,18 @@ __metadata:
     terser-webpack-plugin: ^5.3.3
     ts-loader: ^9.2.6
     ts-node: ^10.8.1
-    typedoc: 0.24.0
+    typedoc: ^0.23.6
     typescript: ^4.7.4
     webpack: ^5.65.0
     webpack-cli: ^4.9.1
   peerDependencies:
-    typedoc: ^0.23.6 || ^0.24.0
+    typedoc: ^0.23.6
   languageName: unknown
   linkType: soft
 
-"typedoc@npm:0.24.0":
-  version: 0.24.0
-  resolution: "typedoc@npm:0.24.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.24.0.tgz"
+"typedoc@npm:^0.23.6":
+  version: 0.23.28
+  resolution: "typedoc@npm:0.23.28::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.23.28.tgz"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.2.12
@@ -6004,7 +6004,7 @@ __metadata:
     typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: 2c53037a8bc448713453e2f314265be058adff64710a83bd0d50a65ac72d4117265d89609c40da46fcd3e35c833f1641ec7c2ecb4b59cc29b8f46e4da5e4d50a
+  checksum: 40eb4e207aac1b734e09400cf03f543642cc7b11000895198dd5a0d3166315759ccf4ac30a2915153597c5c186101c72bac2f1fc12b428184a9274d3a0e44c5e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,7 +3708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.2.12":
+"marked@npm:^4.3.0":
   version: 4.3.0
   resolution: "marked@npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-4.3.0.tgz"
   bin:
@@ -4120,12 +4120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^7.1.3":
-  version: 7.4.6
-  resolution: "minimatch@npm:7.4.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-7.4.6.tgz"
+"minimatch@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "minimatch@npm:9.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-9.0.1.tgz"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 1a6c8d22618df9d2a88aabeef1de5622eb7b558e9f8010be791cb6b0fa6e102d39b11c28d75b855a1e377b12edc7db8ff12a99c20353441caa6a05e78deb5da9
+  checksum: 97f5f5284bb57dc65b9415dec7f17a0f6531a33572193991c60ff18450dcfad5c2dad24ffeaf60b5261dccd63aae58cc3306e2209d57e7f88c51295a532d8ec3
   languageName: node
   linkType: hard
 
@@ -5983,28 +5983,28 @@ __metadata:
     terser-webpack-plugin: ^5.3.3
     ts-loader: ^9.2.6
     ts-node: ^10.8.1
-    typedoc: ^0.23.6
+    typedoc: ^0.24.8
     typescript: ^4.7.4
     webpack: ^5.65.0
     webpack-cli: ^4.9.1
   peerDependencies:
-    typedoc: ^0.23.6
+    typedoc: ^0.24.0
   languageName: unknown
   linkType: soft
 
-"typedoc@npm:^0.23.6":
-  version: 0.23.28
-  resolution: "typedoc@npm:0.23.28::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.23.28.tgz"
+"typedoc@npm:^0.24.8":
+  version: 0.24.8
+  resolution: "typedoc@npm:0.24.8::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedoc%2F-%2Ftypedoc-0.24.8.tgz"
   dependencies:
     lunr: ^2.3.9
-    marked: ^4.2.12
-    minimatch: ^7.1.3
+    marked: ^4.3.0
+    minimatch: ^9.0.0
     shiki: ^0.14.1
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
   bin:
     typedoc: bin/typedoc
-  checksum: 40eb4e207aac1b734e09400cf03f543642cc7b11000895198dd5a0d3166315759ccf4ac30a2915153597c5c186101c72bac2f1fc12b428184a9274d3a0e44c5e
+  checksum: a46a14497f789fb3594e6c3af2e45276934ac46df40b7ed15a504ee51dc7a8013a2ffb3a54fd73abca6a2b71f97d3ec9ad356fa9aa81d29743e4645a965a2ae0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 I have a  same problem with #21 using this theme.
Fix an error by a different path seperator between fullFileName and process.cwd() in Windows.
![hierarchy_paths](https://github.com/DiFuks/typedoc-theme-hierarchy/assets/60977531/730ba201-d357-4852-bb00-88bc0f6c4d09)

Anyway, for fixing this problem, I cloned this repository and run `yarn install`,
However, this is my fist time using `yarn` and I'm not sure that I installed the packages correctly.
I had problem installing packages(like `eslint-config-fuks`), so I'm worried little bit.