### PR TITLE
Updates to support TypeDoc 0.25.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^4.9.1"
   },
   "peerDependencies": {
-    "typedoc": ">=0.24.0"
+    "typedoc": "^0.24.0 || ^0.25.0"
   },
   "scripts": {
     "build": "webpack && tsc --project tsconfig.build.json",

--- a/src/themes/OverrideTheme.tsx
+++ b/src/themes/OverrideTheme.tsx
@@ -7,8 +7,6 @@ import { Renderer } from 'typedoc/dist/lib/output/renderer';
 import { OverrideThemeContext } from './OverrideThemeContext';
 
 export class OverrideTheme extends DefaultTheme {
-  private _contextCache?: OverrideThemeContext;
-
   public constructor(renderer: Renderer) {
     super(renderer);
 
@@ -27,12 +25,10 @@ export class OverrideTheme extends DefaultTheme {
   public override getRenderContext(
     page: PageEvent<Reflection>,
   ): OverrideThemeContext {
-    this._contextCache ||= new OverrideThemeContext(
+    return new OverrideThemeContext(
       this,
       page,
       this.application.options,
     );
-
-    return this._contextCache;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5867,7 +5867,7 @@ __metadata:
     webpack: ^5.65.0
     webpack-cli: ^4.9.1
   peerDependencies:
-    typedoc: ">=0.24.0"
+    typedoc: ^0.24.0 || ^0.25.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I went to recommend this to someone, and noticed it didn't show up in TypeDoc's [themes](https://typedoc.org/guides/themes/) page as having support for 0.25.x. This is because TypeDoc's site filters out plugins/themes which make unreasonable claims about supporting versions to try to avoid recommending broken packages.

This also removes the context cache from the theme. Now that the context includes the current page, it isn't safe to reuse the same context for each page (unless you overwrite the page member on that object) since pieces of TypeDoc assume that the page exists. Currently, this didn't really matter since the only part of TypeDoc that uses it is the piece that builds the "On this page" navigation section, but if you decide to implement #27, this becomes an important change.